### PR TITLE
fix windows install trough conda

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,11 @@ Installation using anaconda
 - Clone the "openspoor" repository
   - `pip install openspoor`
 - create an environment:
-  - `conda create -n openspoorenv python==3.6.12`
+  - `conda create -n openspoorenv python==3.8`
 - activate the environment:
   - `conda activate openspoorenv`
-- If you are installing on **Windows OS** with Anaconda, first install rtree and geopandas through anaconda with the commands: 
-  - `conda install rtree==0.8.3 -y`
-  - `conda install geopandas==0.6.1 -y`
-- In the root directory of the repository, execute the command:
-  - `pip install -r requirements.txt`
+- install dependencies:
+  - `conda install -c conda-forge --file requirements.txt`
 - In the root directory of the repository, execute the command:
   - `pip install .`
 - In the root directory of the repository, execute the command: 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 geopandas==0.6.1
-loguru==0.4.0
+loguru==0.4.1
 pytest==5.4.1
 requests==2.22.0
-rtree==0.8.3
+rtree==0.9.7
 pyproj==2.4.1
 pyyaml==5.4.1


### PR DESCRIPTION
loguru 0.4.0 is not available on conda-forge only 0.4.1
old rtree will not properly install on windows, needed an updated version

simplified the readme to just conda install with conda-forge as extra channel.
This will now work in windows as well as mac/unix

Switched to Python 3.8 in the readme (because I could, all the unit tests were still green)