### PR TITLE
fix pyproj version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ requirements = [
     "loguru",
     "requests",
     "rtree",
-    "pyproj<3",
+    "pyproj",
     "pandas",
     "shapely",
     "folium"


### PR DESCRIPTION
pyproj < 3 did not work for Apple devices (with M1 chip), and the package works on Windows without this requirement. Furthermore, the <3 version requirement in setup.py is inconsistent with the 3.3.* requirements in requirements.txt, so it makes sense to remove the <3 requirement in setup.py