### PR TITLE
Kleine bugfix: drop duplicates makes sure that merge returns same size df as input df

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,13 @@ Use conda to install Fiona and GDAL:
 
 #### Mac/Linux
 
+- `conda create -n [env_name] python=3.8`
+- `conda install -c conda-forge proj=7.0.0`
+- `conda install -c conda-forge pyproj=2.6.0`
 - `pip install openspoor`
+
+The steps above involving conda(-forge) are necessary for Mac M1 chips (used since Nov 2020). In case your Mac does not
+have a M1 chip, then `pip install openspoor` should suffice.
 
 ### Installation - development
 

--- a/openspoor/transformers/TransformerGeocodeToCoordinates.py
+++ b/openspoor/transformers/TransformerGeocodeToCoordinates.py
@@ -47,7 +47,7 @@ class TransformerGeocodeToCoordinates:
                    columns.
         :return: A pandas dataframe with x, y coordinate columns
         """
-        xy_information = self._geocode_naar_xy(df)
+        xy_information = self._geocode_naar_xy(df).drop_duplicates()
 
         # The index steps are required to keep the index of df
         index = df.index

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ dev_packages = [
 ]
 
 setup(name='openspoor',
-      version='0.1.9',
+      version='0.1.9.1',
       description='Open source project to allow translations between different spoor referential systems',
       long_description=(Path(__file__).parent / "README.md").read_text(),
       long_description_content_type='text/markdown',


### PR DESCRIPTION
Tijdens het gebruik van TransformerGeocodeToCoordinates zag ik dat df_with_xy.index = index fout ging omdat de df_with_xy groter was geworden dan de input df. Dit komt omdat er duplicaten in xy_information zitten (geen idee waarom), maar dit is dus gefixt met een drop_duplicates.
