### PR TITLE
Fix map layer

### DIFF
--- a/openspoor/mapservices/MapservicesQuery.py
+++ b/openspoor/mapservices/MapservicesQuery.py
@@ -196,7 +196,12 @@ class MapServicesQuery:
         res = SafeRequest().get_json(
             "GET", input_url + "&returnCountOnly=True"
         )
-        return res["properties"]["count"]
+        if "count" in res:
+            return res["count"]
+        elif "properties" in res and "count" in res["properties"]:
+            return res["properties"]["count"]
+        else:
+            raise ValueError("Count not found in response")
 
     def _retrieve_batch_of_features_to_gdf(
         self, input_url: str, offset: int

--- a/openspoor/mapservices/MapservicesQuery.py
+++ b/openspoor/mapservices/MapservicesQuery.py
@@ -196,11 +196,6 @@ class MapServicesQuery:
         res = SafeRequest().get_json(
             "GET", input_url + "&returnCountOnly=True"
         )
-        # some layers do not return geojson when asking for the count only
-        # i.e.: 'https://mapservices.prorail.nl/
-        # arcgis/rest/services/Kadastraal_004/MapServer/5'
-        if "properties" not in res.keys():
-            return res["count"]
         return res["properties"]["count"]
 
     def _retrieve_batch_of_features_to_gdf(

--- a/openspoor/visualisations/trackmap.py
+++ b/openspoor/visualisations/trackmap.py
@@ -104,8 +104,7 @@ class TrackMap(folium.Map):
             tiles=None,
             **kwargs,
         )
-        if add_aerial:
-            self._add_aerial_photograph()
+        self._add_layers(add_aerial)
 
         if not isinstance(objects, list):
             self.add(objects)
@@ -117,7 +116,7 @@ class TrackMap(folium.Map):
             ), f"Unable to plot {obj}, not defined as plottable object"
             self.add(obj)
 
-    def _add_aerial_photograph(self) -> None:
+    def _add_layers(self, add_aerial) -> None:
         """
         Add the most recent ProRail aerial photograph to the map.
 
@@ -128,14 +127,15 @@ class TrackMap(folium.Map):
         fg = folium.FeatureGroup(
             name="aerial_photograph", max_zoom=30, max_native_zoom=30
         )
-        folium.WmsTileLayer(
-            url="https://luchtfoto.prorail.nl/erdas-iws/ogc/wms/Luchtfoto",
-            layers="meest_recent",
-            transparent=True,
-            overlay=False,
-            maxZoom=30,
-            maxNativeZoom=30,
-        ).add_to(fg)
+        if add_aerial:
+            folium.WmsTileLayer(
+                url="https://luchtfoto.prorail.nl/erdas-iws/ogc/wms/Luchtfoto",
+                layers="meest_recent",
+                transparent=True,
+                overlay=False,
+                maxZoom=30,
+                maxNativeZoom=30,
+            ).add_to(fg)
         # Use CartoDB Positron to avoid OSM referer issues
         folium.TileLayer(
             tiles="https://{s}.basemaps.cartocdn.com"
@@ -147,7 +147,7 @@ class TrackMap(folium.Map):
             transparent=True,
             opacity=0.2,
             subdomains="abcd",
-            maxZoom=19,
+            maxZoom=30,
         ).add_to(fg)
         self.add_child(fg)
 

--- a/openspoor/visualisations/trackmap.py
+++ b/openspoor/visualisations/trackmap.py
@@ -136,8 +136,18 @@ class TrackMap(folium.Map):
             maxZoom=30,
             maxNativeZoom=30,
         ).add_to(fg)
+        # Use CartoDB Positron to avoid OSM referer issues
         folium.TileLayer(
-            "openstreetmap", transparent=True, opacity=0.2
+            tiles="https://{s}.basemaps.cartocdn.com"
+            "/light_all/{z}/{x}/{y}{r}.png",
+            attr='&copy; <a href="https://www.openstreetmap.org/copyright">'
+            "OpenStreetMap</a> contributors &copy;"
+            '<a href="https://carto.com/attributions">CARTO</a>',
+            name="CartoDB Light",
+            transparent=True,
+            opacity=0.2,
+            subdomains="abcd",
+            maxZoom=19,
         ).add_to(fg)
         self.add_child(fg)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "openspoor"
-version = "0.3.4"
+version = "0.3.5"
 description = "Open source project to allow translations between different spoor referential systems"
 authors = [{ name = "Your Name", email = "your.email@example.com" }]
 requires-python = ">=3.10,<4"

--- a/tests/test_Acceptance.py
+++ b/tests/test_Acceptance.py
@@ -844,20 +844,3 @@ class Test:
             }
         )
         pd.testing.assert_frame_equal(output, expected_output)
-
-    def test_acceptance_query_functionality(self):
-        data = MapServicesQuery(
-            url="http://mapservices.prorail.nl/"
-            + "arcgis/rest/services/Kadastraal_004/MapServer/5"
-        )
-        query_dict = {
-            "KADSLEUTEL": ["ANM00G3774", "ANM00G3775", "ANM00H483"],
-            "KADGEM": ["ANM00"],
-        }
-
-        output = data._load_all_features_to_gdf(dict_query=query_dict)
-
-        assert (
-            output["KADSLEUTEL"][0]
-            in ["ANM00G3774", "ANM00G3775", "ANM00H483"]
-        ) & (output["GEMEENTE"][0] == "Arnemuiden")

--- a/tests/test_MapservicesData.py
+++ b/tests/test_MapservicesData.py
@@ -1,5 +1,8 @@
+from unittest.mock import MagicMock, patch
+
 import geopandas as gpd
 import pandas as pd
+import pytest
 from shapely.geometry import LineString, Point, Polygon
 
 from openspoor.mapservices import MapServicesQuery
@@ -100,3 +103,48 @@ class Test:
             ],
         )
         pd.testing.assert_frame_equal(output_data, expected_output)
+
+    @patch("openspoor.mapservices.MapservicesQuery.SafeRequest")
+    def test_retrieve_max_features_count_json_format(self, mock_safe_request):
+        """Test with JSON format response (f=json)"""
+        # Mock the SafeRequest to return JSON format response
+        mock_instance = MagicMock()
+        mock_safe_request.return_value = mock_instance
+        mock_instance.get_json.return_value = {"count": 123}
+
+        result = MapServicesQuery._retrieve_max_features_count("test_url")
+
+        assert result == 123
+        mock_instance.get_json.assert_called_once_with(
+            "GET", "test_url&returnCountOnly=True"
+        )
+
+    @patch("openspoor.mapservices.MapservicesQuery.SafeRequest")
+    def test_retrieve_max_features_count_geojson_format(
+        self, mock_safe_request
+    ):
+        """Test with GeoJSON format response (f=geojson)"""
+        # Mock the SafeRequest to return GeoJSON format response
+        mock_instance = MagicMock()
+        mock_safe_request.return_value = mock_instance
+        mock_instance.get_json.return_value = {"properties": {"count": 456}}
+
+        result = MapServicesQuery._retrieve_max_features_count("test_url")
+
+        assert result == 456
+        mock_instance.get_json.assert_called_once_with(
+            "GET", "test_url&returnCountOnly=True"
+        )
+
+    @patch("openspoor.mapservices.MapservicesQuery.SafeRequest")
+    def test_retrieve_max_features_count_missing_count(
+        self, mock_safe_request
+    ):
+        """Test when count is not found in response"""
+        # Mock the SafeRequest to return response without count
+        mock_instance = MagicMock()
+        mock_safe_request.return_value = mock_instance
+        mock_instance.get_json.return_value = {"some_other_key": "value"}
+
+        with pytest.raises(ValueError, match="Count not found in response"):
+            MapServicesQuery._retrieve_max_features_count("test_url")

--- a/tests/visualisations/test_trackmap.py
+++ b/tests/visualisations/test_trackmap.py
@@ -148,8 +148,8 @@ def test_add_to_trackmap(
     PlottingAreas(areas_geodataframe, popup=["name2"]).add_to(m)
 
     # For the points and areas, 1 child is added for every row in the dataframe
-    # 1 child always exists when the aerial photograph is added
-    aerial_photograph_children = add_aerial
+    # 1 FeatureGroup always exists for map layers
+    base_featuregroup_children = 1
     # Linestrings always add 2 objects; one for the hover,
     # and one for the lines themselves
     linestring_children = 2
@@ -157,8 +157,38 @@ def test_add_to_trackmap(
         len(points_dataframe)
         + linestring_children
         + len(areas_geodataframe)
-        + aerial_photograph_children
+        + base_featuregroup_children
     )
+
+    assert len(m._children) == total_objects, "Invalid number of items added"
+
+    # Check that the FeatureGroup contains the correct number of layers
+    # Find the FeatureGroup and count its tile layers
+    layer_featuregroup = None
+    for child in m._children.values():
+        if isinstance(child, folium.FeatureGroup):
+            layer_featuregroup = child
+            break
+
+    assert layer_featuregroup is not None, "No FeatureGroup found"
+
+    # Count tile layers in the FeatureGroup
+    tile_layers = [
+        child
+        for child in layer_featuregroup._children.values()
+        if isinstance(
+            child,
+            (
+                folium.raster_layers.TileLayer,
+                folium.raster_layers.WmsTileLayer,
+            ),
+        )
+    ]
+
+    expected_layers = 2 if add_aerial else 1  # CartoDB + aerial (if enabled)
+    assert (
+        len(tile_layers) == expected_layers
+    ), f"Expected {expected_layers} tile layers, got {len(tile_layers)}"
 
     assert len(m._children) == total_objects, "Invalid number of items added"
 


### PR DESCRIPTION
Due to openstreetmap policies you sometimes got these errors; these should be fixed now. Also removed deprecated functionality (the referenced layer did not exist, nor any others that used the specific logic for that). 
<img width="452" height="382" alt="image" src="https://github.com/user-attachments/assets/7da5edcc-2adc-4aab-b581-d9a6c3e9f806" />
